### PR TITLE
Add CKiD U25 equations

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Xavier Gaeta MD PhD
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/R/nephro.R
+++ b/R/nephro.R
@@ -884,14 +884,14 @@ CKiD.U25.combined <- function(creatinine, cystatin, age, ht, sex, verbose = FALS
     eGFRU25.cr <- CKiD.U25.creatinine(creatinine = creatinine, age = age,
                                       ht = ht, sex = sex)
     eGFRU25.cys <-  CKiD.U25.cystatin(cystatin = cystatin, age = age, sex = sex)
-    sGFRU25.avg <- (eGFRU25.cys + eGFRU25.cr) / 2
+    eGFRU25.avg <- (eGFRU25.cys + eGFRU25.cr) / 2
 
     ## Determine if we should return all the component parts or just the result
     ## of the combined calculation
     if(verbose) {
-      return(round(cbind(eGFRU25.cr, eGFRU25.cys, sGFRU25.avg),1))
+      return(round(cbind(eGFRU25.cr, eGFRU25.cys, eGFRU25.avg),1))
     } else {
-      return(round(sGFRU25.avg, 1))
+      return(round(eGFRU25.avg, 1))
     }
 
   } else

--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# Nephro with CKiD U25 equations
+Xavier Gaeta MD, PhD
+
+## Nephro - CKiD U25
+
+This is fork of the R **nephro** package that’s hosted on CRAN.org which
+includes functions to calculate pediatric eGFR based on the following
+publication:
+
+Pierce CB, Muñoz A, Ng DK, Warady BA, Furth SL, Schwartz GJ. **Age- and
+sex-dependent clinical equations to estimate glomerular filtration rates
+in children and young adults with chronic kidney disease.** *Kidney
+International*. 2021;99(4):948–956.
+[doi:10.1016/j.kint.2020.10.047](https://doi.org/10.1016/j.kint.2020.10.047 "Persistent DOI link for Pierce et al. paper")
+
+## Installation
+
+You can install the package from Github
+
+``` r
+devtools::install_github("xgaeta/nephro-CKiD")
+```
+
+then include the package in your script:
+
+``` r
+library(nephro)
+```
+
+## Using the functions
+
+These new equations follow the same style as the rest of the package,
+including sex as a binary variable with 0 for female and 1 for male.
+Height is provided in cm. They currently use US based equations. Outputs
+are in mL/min/1.73m<sup>2</sup>.
+
+``` r
+CKiD.U25.cystatin(cystatin = 1.2, age = 9.5, sex = 0)
+```
+
+    [1] 68.4
+
+``` r
+CKiD.U25.creatinine(creatinine = 0.8, age = 9.5, sex = 0, ht = 132)
+```
+
+    [1] 63.1
+
+``` r
+CKiD.U25.combined(creatinine = 0.8, cystatin = 1.2, age = 9.5, sex = 0, ht = 132, verbose = TRUE)
+```
+
+         eGFRU25.cr eGFRU25.cys sGFRU25.avg
+    [1,]       63.1        68.4        65.8
+
+Pull requests have been filed to merge these equations into the main
+**nephro** package

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CKiD.U25.combined(creatinine = 0.8, cystatin = 1.2, age = 9.5, sex = 1, ht = 132
     [1,]       58.4        65.9        62.2
 
 [Pull requests have been
-filed](https://github.com/cran/nephro/pulls "Current status of CKiD U25 pull request")
+filed](https://github.com/cran/nephro/pull/1 "Current status of CKiD U25 pull request")
 to merge these equations into the main
 [**nephro**](https://cran.r-project.org/web/packages/nephro/index.html "CRAN repository for original nephro package, currently v1.4")
 package

--- a/README.md
+++ b/README.md
@@ -31,28 +31,28 @@ library(nephro)
 ## Using the functions
 
 These new equations follow the same style as the rest of the package,
-including sex as a binary variable with 0 for female and 1 for male.
+including sex as a binary variable with 0 for male and 1 for female.
 Height is provided in cm. They currently use US based equations. Outputs
 are in mL/min/1.73m<sup>2</sup>.
 
 ``` r
-CKiD.U25.cystatin(cystatin = 1.2, age = 9.5, sex = 0)
+CKiD.U25.cystatin(cystatin = 1.2, age = 9.5, sex = 1)
 ```
 
-    [1] 68.4
+    [1] 65.9
 
 ``` r
-CKiD.U25.creatinine(creatinine = 0.8, age = 9.5, sex = 0, ht = 132)
+CKiD.U25.creatinine(creatinine = 0.8, age = 9.5, sex = 1, ht = 132)
 ```
 
-    [1] 63.1
+    [1] 58.4
 
 ``` r
-CKiD.U25.combined(creatinine = 0.8, cystatin = 1.2, age = 9.5, sex = 0, ht = 132, verbose = TRUE)
+CKiD.U25.combined(creatinine = 0.8, cystatin = 1.2, age = 9.5, sex = 1, ht = 132, verbose = TRUE)
 ```
 
          eGFRU25.cr eGFRU25.cys eGFRU25.avg
-    [1,]       63.1        68.4        65.8
+    [1,]       58.4        65.9        62.2
 
 [Pull requests have been
 filed](https://github.com/cran/nephro/pulls "Current status of CKiD U25 pull request")

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Nephro with CKiD U25 equations
-Xavier Gaeta MD, PhD
+**Xavier Gaeta MD, PhD**
 
 ## Nephro - CKiD U25
 
-This is fork of the R **nephro** package that’s hosted on CRAN.org which
-includes functions to calculate pediatric eGFR based on the following
-publication:
+This is a fork of the R
+[**nephro**](https://cran.r-project.org/web/packages/nephro/index.html "CRAN repository for original nephro package, currently v1.4")
+package that’s hosted on CRAN.org which includes functions to calculate
+pediatric eGFR based on the following publication:
 
 Pierce CB, Muñoz A, Ng DK, Warady BA, Furth SL, Schwartz GJ. **Age- and
 sex-dependent clinical equations to estimate glomerular filtration rates
@@ -53,5 +54,8 @@ CKiD.U25.combined(creatinine = 0.8, cystatin = 1.2, age = 9.5, sex = 0, ht = 132
          eGFRU25.cr eGFRU25.cys eGFRU25.avg
     [1,]       63.1        68.4        65.8
 
-Pull requests have been filed to merge these equations into the main
-**nephro** package
+[Pull requests have been
+filed](https://github.com/cran/nephro/pulls "Current status of CKiD U25 pull request")
+to merge these equations into the main
+[**nephro**](https://cran.r-project.org/web/packages/nephro/index.html "CRAN repository for original nephro package, currently v1.4")
+package

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ CKiD.U25.creatinine(creatinine = 0.8, age = 9.5, sex = 0, ht = 132)
 CKiD.U25.combined(creatinine = 0.8, cystatin = 1.2, age = 9.5, sex = 0, ht = 132, verbose = TRUE)
 ```
 
-         eGFRU25.cr eGFRU25.cys sGFRU25.avg
+         eGFRU25.cr eGFRU25.cys eGFRU25.avg
     [1,]       63.1        68.4        65.8
 
 Pull requests have been filed to merge these equations into the main


### PR DESCRIPTION
I have added functions to calculate eGFR for children ages 1-25 using the CKiD U25 algorithms. These include calculations based on serum creatinine, based on Cystatin C, and a composite based on both.

References:
Pierce CB, Muñoz A, Ng DK, Warady BA, Furth SL, Schwartz GJ. Age- and sex-dependent clinical equations to estimate glomerular filtration rates in children and young adults with chronic kidney disease. Kidney International. 2021;99(4):948–956. doi:10.1016/j.kint.2020.10.047

[](https://www.niddk.nih.gov/research-funding/research-programs/kidney-clinical-research-epidemiology/laboratory/glomerular-filtration-rate-equations/children-adolescents-young-adults#ckid-u25)